### PR TITLE
Prioritize the remote "origin" over others:

### DIFF
--- a/lib/ci_runner/git_helper.rb
+++ b/lib/ci_runner/git_helper.rb
@@ -55,7 +55,11 @@ module CIRunner
     # Try to get the right repository depending on the remotes. It's quite common to have two remotes when your
     # work on a forked project. The remote from the source project is regularly called: "remote".
     #
-    # CI Runner will prefer the repository name for the remote "remote" over others.
+    # CI Runner will prioritize remotes with the following order:
+    #
+    # - remote
+    # - origin
+    # - anything else
     #
     # @param stdout [String] The output from the `git remote -v` command.
     #
@@ -73,6 +77,10 @@ module CIRunner
     #    rails/rails will be returned.
     def process_remotes(stdout)
       stdout.match(/remote#{remote_regex}/) do |match_data|
+        return "#{match_data[1]}/#{match_data[2]}"
+      end
+
+      stdout.match(/origin#{remote_regex}/) do |match_data|
         return "#{match_data[1]}/#{match_data[2]}"
       end
 

--- a/test/git_helper_test.rb
+++ b/test/git_helper_test.rb
@@ -83,6 +83,27 @@ module CIRunner
       assert_equal("some_name/ci_runner", repository)
     end
 
+    def test_repository_from_remote_origin_has_precedence
+      _, status = Open3.capture2("git remote add some_remote https://github.com/Edouard-chin/ci_runner.git")
+      raise("Couldn't add a remote to the test git repository") unless status.success?
+
+      _, status = Open3.capture2("git remote add remote https://github.com/some_name/ci_runner.git")
+      raise("Couldn't add a remote to the test git repository") unless status.success?
+
+      repository = GitHelper.repository_from_remote
+
+      assert_equal("some_name/ci_runner", repository)
+    end
+
+    def test_repository_from_remote_with_different_name
+      _, status = Open3.capture2("git remote add some_remote https://github.com/Edouard-chin/ci_runner.git")
+      raise("Couldn't add a remote to the test git repository") unless status.success?
+
+      repository = GitHelper.repository_from_remote
+
+      assert_equal("Edouard-chin/ci_runner", repository)
+    end
+
     def test_repository_from_remote_raise_when_repository_cant_be_determined
       _, status = Open3.capture2("git remote add origin https://scv.com/Edouard-chin/ci_runner.git")
       raise("Couldn't add a remote to the test git repository") unless status.success?


### PR DESCRIPTION
- The order of priority is now:

  1) remote
  2) origin
  3) everything else