### PR TITLE
Handle when the log output has no test failures:

### DIFF
--- a/lib/ci_runner/log_downloader.rb
+++ b/lib/ci_runner/log_downloader.rb
@@ -28,7 +28,7 @@ module CIRunner
     # @param block [Proc, Lambda] A proc that gets called if fetching the logs from GitHub fails. Allows the CLI to
     #   prematurely exit while cleaning up the CLI::UI frame.
     #
-    # @return [File] A file ready to be read.
+    # @return [Pathname] The path to the log file.
     def fetch(&block)
       return cached_log if cached_log
 


### PR DESCRIPTION
Handle when the log output has no test failures:

- This can happen for two reasons:

  1) The selected CI isn't running the test suite (Maybe the user
     select a CI running something else).
  2) The application has custom minitest/RSpec reporters and the set
     of default regexes from CIRunner doesn't match.

  If CIRunner detects no failures from the log, it will bail out
  and let the user know those two reasons.