### PR TITLE
Fix tests flakyness:

### DIFF
--- a/test/runners/minitest_runner_test.rb
+++ b/test/runners/minitest_runner_test.rb
@@ -7,10 +7,10 @@ require "fileutils"
 module CIRunner
   module Runners
     class MinitestRunnerTest < Minitest::Test
-      def setup
-        super
-
+      def teardown
         Configuration::Project.instance.load!
+
+        super
       end
 
       def test_parse_raw_minitest_log_failures


### PR DESCRIPTION
Fix tests flakyness:

- Need to reset the Configuration singleton after each tests, otherwise
  it leaks to other tests that relies on having a default
  configuration.