### PR TITLE
Various fixes

### DIFF
--- a/lib/ci_runner/runners/base.rb
+++ b/lib/ci_runner/runners/base.rb
@@ -43,13 +43,15 @@ module CIRunner
       # @return [void]
       def parse!
         @ci_log.each_line do |line|
-          case line
+          line_no_ansi_color = line.gsub(/\e\[\d+m/, "")
+
+          case line_no_ansi_color
           when seed_regex
             @seed = first_matching_group(Regexp.last_match)
           when ruby_detection_regex
             @ruby_version = first_matching_group(Regexp.last_match)
 
-            @buffer << line if buffering?
+            @buffer << line_no_ansi_color if buffering?
           when gemfile_detection_regex
             @gemfile = first_matching_group(Regexp.last_match)
           when buffer_detection_regex
@@ -58,9 +60,9 @@ module CIRunner
               @buffer.clear
             end
 
-            @buffer << line
+            @buffer << line_no_ansi_color
           else
-            @buffer << line if buffering?
+            @buffer << line_no_ansi_color if buffering?
           end
         end
 

--- a/lib/ci_runner/runners/minitest_runner.rb
+++ b/lib/ci_runner/runners/minitest_runner.rb
@@ -40,7 +40,7 @@ module CIRunner
       def self.match?(ci_log)
         default_reporter = %r{(Finished in) \d+\.\d{6}s, \d+\.\d{4} runs/s, \d+\.\d{4} assertions/s\.}
 
-        Regexp.union(default_reporter, SEED_REGEX, "minitest").match?(ci_log)
+        Regexp.union(default_reporter, SEED_REGEX).match?(ci_log)
       end
 
       # @return [String] See Runners::Base#report

--- a/lib/ci_runner/runners/rspec.rb
+++ b/lib/ci_runner/runners/rspec.rb
@@ -15,7 +15,7 @@ module CIRunner
         command = /bundle exec rspec/
         summary = /Failed examples:/
 
-        Regexp.union(command, summary, /rspec/i).match?(log)
+        Regexp.union(command, summary).match?(log)
       end
 
       # @return [String] See Runners::Base#report

--- a/test/fixtures/rspec_colored.log
+++ b/test/fixtures/rspec_colored.log
@@ -1,0 +1,25 @@
+Failures:
+
+  1) customer edit page displays selectable strings as dropdowns
+     [31mFailure/Error: [0mselect [31m[1;31m"[0m[31mvip[1;31m"[0m[31m[0m, [35mfrom[0m: [31m[1;31m"[0m[31mKind[1;31m"[0m[31m[0m[0m
+     [31m[0m
+     [31mCapybara::ElementNotFound:[0m
+     [31m  Unable to find select box "Kind" that is not disabled and Unable to find input box with datalist completion "Kind" that is not disabled[0m
+     [36m# ./spec/features/edit_page_spec.rb:43:in `block (2 levels) in <top (required)>'[0m
+     [36m# ------------------[0m
+     [36m# --- Caused by: ---[0m
+     [36m# Capybara::ElementNotFound:[0m
+     [36m#   Unable to find select box "Kind" that is not disabled[0m
+     [36m#   ./spec/features/edit_page_spec.rb:43:in `block (2 levels) in <top (required)>'[0m
+
+Finished in 18.6 seconds (files took 3.35 seconds to load)
+[31m541 examples, 1 failure[0m
+
+Failed examples:
+
+[31mrspec ./spec/features/edit_page_spec.rb:39[0m [36m# customer edit page displays selectable strings as dropdowns[0m
+
+Randomized with seed 2668
+
+
+Exited with code exit status 1

--- a/test/integration/cli_test.rb
+++ b/test/integration/cli_test.rb
@@ -155,7 +155,7 @@ module CIRunner
       stub_request(:get, "https://api.github.com/repos/foo/bar/actions/jobs/1/logs")
         .to_return(status: 302, headers: { "Location" => "https://example.com/download" })
       stub_request(:get, "https://example.com/download")
-        .to_return(status: 200, body: "minitest")
+        .to_return(status: 200, body: "Running tests with run options --seed 20218:")
 
       stdout, _ = capture_io do
         CLI.start(["--commit", "abc", "--repository", "foo/bar"])

--- a/test/runners/rspec_test.rb
+++ b/test/runners/rspec_test.rb
@@ -18,6 +18,19 @@ module CIRunner
         assert_equal(expected.path, runner.failures[0].path)
       end
 
+      def test_parse_return_failures_when_output_is_colored
+        runner = RSpec.new(read_fixture("rspec_colored.log"))
+        runner.parse!
+
+        expected_test_name = "customer edit page displays selectable strings as dropdowns"
+        expected = TestFailure.new(nil, expected_test_name, "./spec/features/edit_page_spec.rb")
+
+        assert_equal(1, runner.failures.count)
+        assert_nil(runner.failures[0].klass)
+        assert_equal(expected.test_name, runner.failures[0].test_name)
+        assert_equal(expected.path, runner.failures[0].path)
+      end
+
       def test_run_one_example
         runner = RSpec.new(nil)
         runner.seed = "1234"


### PR DESCRIPTION
Remove "minitest" and "rspec" pattern when detecting the runner:

- Those patterns are too generic. If a project uses RSpec as its test
  framework but there is a "minitest" output somewhere in the log
  (or the other way around), CI Runner guess on what runner to use
  would be wrong.

--------

Remove ansi colors before parsing