### PR TITLE
Add a TODO to remind me to revisit the TestFailure relative path:

### DIFF
--- a/lib/ci_runner/test_failure.rb
+++ b/lib/ci_runner/test_failure.rb
@@ -56,6 +56,9 @@ module CIRunner
 
       regex = %r{.*/?(test/.*?)\Z}
       unless path.to_s.match?(regex)
+        # TODO(on: "2022-09-10", to: "edouard-chin") Revisit this as it's too brittle.
+        #   If a test file doesn't live the in the `test/` root folder, this will raise an error.
+        #   I should instead warn the user and move on.
         raise "Can't create a relative path."
       end
 


### PR DESCRIPTION
Add a TODO to remind me to revisit the TestFailure relative path:

- I originally added this when a log output points a failure to an
  absolute path:
  `/root/github/var/project/project/test/my_file.rb`.

  The `/root/github/var/project/project/` part is specific to the CI
  and won't exist on the user machine so I need the relative path
  (`test/my_file.rb`).