### PR TITLE
Add a mechanism to tell users when a new version of CI Runner exists:

### DIFF
--- a/lib/ci_runner.rb
+++ b/lib/ci_runner.rb
@@ -6,11 +6,12 @@ require_relative "ci_runner/version"
 module CIRunner
   Error = Class.new(StandardError)
 
-  autoload :CLI,            "ci_runner/cli"
-  autoload :GitHelper,      "ci_runner/git_helper"
-  autoload :TestRunFinder,  "ci_runner/test_run_finder"
-  autoload :LogDownloader,  "ci_runner/log_downloader"
-  autoload :TestFailure,    "ci_runner/test_failure"
+  autoload :CLI,             "ci_runner/cli"
+  autoload :GitHelper,       "ci_runner/git_helper"
+  autoload :TestRunFinder,   "ci_runner/test_run_finder"
+  autoload :LogDownloader,   "ci_runner/log_downloader"
+  autoload :TestFailure,     "ci_runner/test_failure"
+  autoload :VersionVerifier, "ci_runner/version_verifier"
 
   module Check
     autoload :Github,      "ci_runner/check/github"

--- a/lib/ci_runner/cli.rb
+++ b/lib/ci_runner/cli.rb
@@ -35,6 +35,7 @@ module CIRunner
     def rerun
       ::CLI::UI::StdoutRouter.enable
 
+      check_for_new_version
       runner = nil
 
       ::CLI::UI.frame("Preparing CI Runner") do
@@ -118,6 +119,21 @@ module CIRunner
     end
 
     private
+
+    # Inform the user of a possible new CI Runner version.
+    #
+    # @return [void]
+    def check_for_new_version
+      version_verifier = VersionVerifier.new
+      return unless version_verifier.new_ci_runner_version?
+
+      ::CLI::UI.puts(<<~EOM)
+        {{info:A newer version of CI Runner is available (#{version_verifier.upstream_version}).}}
+        {{info:You can update CI Runner by running}} {{command:gem update ci_runner}}
+      EOM
+    rescue StandardError
+      nil
+    end
 
     # Retrieve all the GitHub CI checks for a given commit. Will be used to interactively prompt
     # the user which one to rerun.

--- a/lib/ci_runner/client/github.rb
+++ b/lib/ci_runner/client/github.rb
@@ -22,6 +22,17 @@ module CIRunner
         get("/user")
       end
 
+      # Get the latest release of a repository.
+      #
+      # @param repository [String] The full repository name, including the owner (rails/rails)
+      #
+      # @return [Hash] See GitHub documentation.
+      #
+      # https://docs.github.com/en/rest/releases/releases#get-the-latest-release
+      def latest_release(repository)
+        get("/repos/#{repository}/releases/latest")
+      end
+
       # Makes an API request to get the CI checks for the +commit+.
       #
       # @param repository [String] The full repository name, including the owner (rails/rails)

--- a/lib/ci_runner/configuration/user.rb
+++ b/lib/ci_runner/configuration/user.rb
@@ -68,6 +68,14 @@ module CIRunner
         save!(@yaml_config)
       end
 
+      # @return [Pathname] The path of the CI Runner directory configuration.
+      #
+      # @example
+      #   puts config_directory # ~/.ci_runner
+      def config_directory
+        config_file.dirname
+      end
+
       # @return [Pathname] The path of the configuration file.
       #
       # @example

--- a/lib/ci_runner/version_verifier.rb
+++ b/lib/ci_runner/version_verifier.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+module CIRunner
+  # Class used to check if a newer version of CI Runner has been released.
+  # This is used to inform the user to update its gem.
+  #
+  # The check only runs every week.
+  class VersionVerifier
+    SEVEN_DAYS = 86_400 * 7
+
+    # Check if the user is running the latest version of CI Runner.
+    #
+    # @return [Boolean]
+    def new_ci_runner_version?
+      return false unless check?
+
+      fetch_upstream_version
+      FileUtils.touch(last_checked)
+
+      upstream_version > Gem::Version.new(VERSION)
+    end
+
+    # Makes a request to GitHub to get the latest release on the Edouard-chin/ci_runner repository
+    #
+    # @return [Gem::Version] An instance of Gem::Version
+    def upstream_version
+      @upstream_version ||= begin
+        release = Client::Github.new(Configuration::User.instance.github_token).latest_release("Edouard-chin/ci_runner")
+
+        Gem::Version.new(release["tag_name"].sub(/\Av/, ""))
+      end
+    end
+    alias_method :fetch_upstream_version, :upstream_version
+
+    # Path of a file used to store when we last checked for a release.
+    #
+    # @return [Pathname]
+    def last_checked
+      Configuration::User.instance.config_directory.join("last-checked")
+    end
+
+    private
+
+    # @return [Boolean] Whether we checked for a release in the 7 days.
+    def check?
+      Time.now > (File.stat(last_checked).mtime + SEVEN_DAYS)
+    rescue Errno::ENOENT
+      true
+    end
+  end
+end

--- a/test/version_verifier_test.rb
+++ b/test/version_verifier_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "fileutils"
+require "date"
+
+module CIRunner
+  class VersionVerifierTest < Minitest::Test
+    def setup
+      Configuration::User.instance.load!
+
+      @verifier = VersionVerifier.new
+    end
+
+    def test_check_version_is_false_when_it_was_checked_less_than_3_days_ago
+      FileUtils.touch(@verifier.last_checked)
+      mtime = File.stat(@verifier.last_checked).mtime
+
+      refute_predicate(@verifier, :new_ci_runner_version?)
+      assert_equal(mtime, File.stat(@verifier.last_checked).mtime)
+    end
+
+    def test_check_version_runs_when_it_was_never_checked
+      stub_request(:get, "https://api.github.com/repos/Edouard-chin/ci_runner/releases/latest")
+        .to_return_json(status: 200, body: { tag_name: "v5.0.0" })
+
+      refute_predicate(@verifier.last_checked, :exist?)
+
+      @verifier.new_ci_runner_version?
+
+      assert_requested(:get, "https://api.github.com/repos/Edouard-chin/ci_runner/releases/latest")
+      assert_predicate(@verifier.last_checked, :exist?)
+    end
+
+    def test_check_version_is_true_when_it_was_checked_more_than_3_days_ago
+      ten_days_ago = Time.now - 864_000
+      FileUtils.touch(@verifier.last_checked, mtime: ten_days_ago)
+
+      stub_request(:get, "https://api.github.com/repos/Edouard-chin/ci_runner/releases/latest")
+        .to_return_json(status: 200, body: { tag_name: "v5.0.0" })
+
+      assert_predicate(@verifier, :new_ci_runner_version?)
+      assert_equal(Date.today, File.stat(@verifier.last_checked).mtime.to_date)
+    end
+
+    def test_check_version_is_false_when_it_was_checked_more_than_3_days_ago_but_there_are_no_new
+      ten_days_ago = Time.now - 864_000
+      FileUtils.touch(@verifier.last_checked, mtime: ten_days_ago)
+
+      stub_request(:get, "https://api.github.com/repos/Edouard-chin/ci_runner/releases/latest")
+        .to_return_json(status: 200, body: { tag_name: "v#{VERSION}" })
+
+      refute_predicate(@verifier, :new_ci_runner_version?)
+      assert_equal(Date.today, File.stat(@verifier.last_checked).mtime.to_date)
+    end
+  end
+end


### PR DESCRIPTION
Add a mechanism to tell users when a new version of CI Runner exists:

- It's quite rare to update gem on your system (more common to manage
  dependencies through bundler.). This change will output a message
  to the user when a newer version of CI Runner exists.

  This is checked only once a week. I don't expect to make many release.